### PR TITLE
RowSingleton class

### DIFF
--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -12,5 +12,5 @@ import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrderi
 import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class CompareSymbol, compareSymbol, class AppendSymbol, appendSymbol)
 import Type.Equality (class TypeEquals, from, to)
-import Type.Row (class RowLacks, class RowToList, class ListToRow, RProxy(..), RLProxy(..))
+import Type.Row (class RowLacks, class RowToList, class ListToRow, class RowSingleton, RProxy(..), RLProxy(..))
 

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -78,7 +78,8 @@ instance listToRowCons
 class ( RowCons label typ () row ) <= RowSingleton (label :: Symbol)
                                                    (typ :: Type)
                                                    (row :: # Type) |
-                                                   -> label typ row
+                                                   label typ -> row,
+                                                   row -> label typ
 
 instance rowSingleton
   :: ( RowToList row (Cons label typ Nil)

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -8,6 +8,7 @@ module Type.Row
   , RLProxy(..)
   , class RowToList
   , class ListToRow
+  , class RowSingleton
   ) where
 
 data RProxy (row :: # Type) = RProxy

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -77,7 +77,7 @@ instance listToRowCons
 class ( RowCons label typ () row ) <= RowSingleton (label :: Symbol)
                                                    (typ :: Type)
                                                    (row :: # Type) |
-                                                   row -> label typ
+                                                   -> label typ row
 
 instance rowSingleton
   :: ( RowToList row (Cons label typ Nil)

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -57,7 +57,7 @@ class RowToList (row :: # Type)
                 (list :: RowList) |
                 row -> list
 
--- | Convert a RowList to a row of types.
+-- | Convert a `RowList` to a row of types.
 -- | The inverse of this operation is `RowToList`.
 class ListToRow (list :: RowList)
                 (row :: # Type) |
@@ -70,3 +70,16 @@ instance listToRowCons
   :: ( ListToRow tail tailRow
      , RowCons label ty tailRow row )
   => ListToRow (Cons label ty tail) row
+
+-- | Obtain the label and type from a singleton row. The functional
+-- | dependencies on `RowCons` mean that it cannot solve this instance, so this
+-- | provides that evidence for that.
+class ( RowCons label typ () row ) <= RowSingleton (label :: Symbol)
+                                                   (typ :: Type)
+                                                   (row :: # Type) |
+                                                   row -> label typ
+
+instance rowSingleton
+  :: ( RowToList row (Cons label typ Nil)
+     , RowCons label typ () row )
+  => RowSingleton label typ row


### PR DESCRIPTION
I think this is a general-purpose operation that can go in with the row operations. Thoughts?

My use case is extracting a named value in tests: ``{acopy} `asserteq` 1`` can display a nice error message that is guaranteed to match the variable name. There's probably other uses for it, but I think it is nice just because it fills in the semantic gap/limitation of `RowCons`.

C.f. https://github.com/purescript/purescript/issues/2809