### PR TITLE
Add type-level list of Symbols and implement insertion sort

### DIFF
--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -10,7 +10,7 @@ module Type.Prelude
 import Type.Data.Boolean (kind Boolean, True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
 import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
 import Type.Proxy (Proxy(..))
-import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class CompareSymbol, compareSymbol, class AppendSymbol, appendSymbol)
+import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class CompareSymbol, compareSymbol, class AppendSymbol, appendSymbol, kind SList, SListProxy(..), SNil, SCons, class Sort, sort)
 import Type.Equality (class TypeEquals, from, to)
 import Type.Row (class RowLacks, class RowToList, class ListToRow, RProxy(..), RLProxy(..))
 


### PR DESCRIPTION
A type-level list of symbols with an insertion sort implementation (in ascending order). If this makes sense for the typelevel prelude, then I could add reversing and appending of these lists too.
(I'm not sure if I correctly followed the coding style)