### PR TITLE
Compiler/0.12

### DIFF
--- a/src/Type/Data/Symbol.purs
+++ b/src/Type/Data/Symbol.purs
@@ -27,7 +27,7 @@ compareSymbol _ _ = OProxy
 class AppendSymbol (lhs :: Symbol)
                    (rhs :: Symbol)
                    (out :: Symbol) |
-                   lhs rhs -> out
+                   lhs rhs -> out, lhs out -> rhs, rhs out -> lhs
 
 appendSymbol :: forall l r o. AppendSymbol l r o => SProxy l -> SProxy r -> SProxy o
 appendSymbol _ _ = SProxy


### PR DESCRIPTION
This PR incorporates the fundeps for running AppendSymbol in reverse, fixing the last test failure on https://github.com/purescript/purescript/pull/3176.