### PR TITLE
Remove attempted re-export of `Prim.Row.Cons`

### DIFF
--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -12,7 +12,8 @@ module Type.Row
   , type (+)
   ) where
 
-import Prim.Row (class Lacks, class Nub, class Cons, class Union)
+import Prim.Row (class Lacks, class Nub, class Union)
+import Prim.Row as Row
 import Prim.RowList (kind RowList, Cons, Nil, class RowToList)
 import Type.Equality (class TypeEquals)
 import Type.Data.Symbol as Symbol
@@ -33,7 +34,7 @@ instance listToRowNil
 
 instance listToCons
   :: ( ListToRow tail tailRow
-     , Cons label ty tailRow row )
+     , Row.Cons label ty tailRow row )
   => ListToRow (Cons label ty tail) row
 
 -- | Remove all occurences of a given label from a RowList


### PR DESCRIPTION
Re: #43.

The changes in this PR follow the suggestion of removing the re-export from the export list.

Let me know if there's more to do or if I missed anything.