### PR TITLE
Add new module Type.RowList

### DIFF
--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -5,6 +5,7 @@ module Type.Prelude
   , module Type.Equality
   , module Type.Proxy
   , module Type.Row
+  , module Type.RowList
   ) where
 
 import Type.Data.Boolean (kind Boolean, True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
@@ -12,5 +13,5 @@ import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrderi
 import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class Compare, compare, class Append, append)
 import Type.Equality (class TypeEquals, from, to)
-import Type.Row (class Union, class Lacks, class RowToList, class ListToRow, RProxy(..), RLProxy(..))
-
+import Type.Row (class Union, class Lacks, RProxy(..))
+import Type.RowList (class RowToList, class ListToRow, RLProxy(..))

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -1,103 +1,12 @@
 module Type.Row
   ( module Prim.Row
   , module RProxy
-  , module Prim.RowList
-  , module RLProxy
-  , class ListToRow
-  , class RowListRemove
-  , class RowListSet
-  , class RowListNub
-  , class RowListAppend
   , RowApply
   , type (+)
   ) where
 
 import Prim.Row (class Lacks, class Nub, class Cons, class Union)
-import Prim.RowList (kind RowList, Cons, Nil, class RowToList)
-import Type.Equality (class TypeEquals)
-import Type.Data.Symbol as Symbol
-import Type.Data.Boolean as Boolean
 import Type.Data.Row (RProxy(..)) as RProxy
-import Type.Data.RowList (RLProxy)
-import Type.Data.RowList (RLProxy(..)) as RLProxy
-
-
--- | Convert a RowList to a row of types.
--- | The inverse of this operation is `RowToList`.
-class ListToRow (list :: RowList)
-                (row :: # Type) |
-                list -> row
-
-instance listToRowNil
-  :: ListToRow Nil ()
-
-instance listToCons
-  :: ( ListToRow tail tailRow
-     , Cons label ty tailRow row )
-  => ListToRow (Cons label ty tail) row
-
--- | Remove all occurences of a given label from a RowList
-class RowListRemove (label :: Symbol)
-                    (input :: RowList)
-                    (output :: RowList)
-                    | label input -> output
-
-instance rowListRemoveNil
-  :: RowListRemove label Nil Nil
-
-instance rowListRemoveCons
-  :: ( RowListRemove label tail tailOutput
-     , Symbol.Equals label key eq
-     , Boolean.If eq
-         (RLProxy tailOutput)
-         (RLProxy (Cons key head tailOutput))
-         (RLProxy output)
-     )
-  => RowListRemove label (Cons key head tail) output
-
--- | Add a label to a RowList after removing other occurences.
-class RowListSet (label :: Symbol)
-                 (typ :: Type)
-                 (input :: RowList)
-                 (output :: RowList)
-                 | label typ input -> output
-
-instance rowListSetImpl
-  :: ( TypeEquals (Symbol.SProxy label) (Symbol.SProxy label')
-     , TypeEquals typ typ'
-     , RowListRemove label input lacking )
-  => RowListSet label typ input (Cons label' typ' lacking)
-
--- | Remove label duplicates, keeps earlier occurrences.
-class RowListNub (input :: RowList)
-                 (output :: RowList)
-                 | input -> output
-
-instance rowListNubNil
-  :: RowListNub Nil Nil
-
-instance rowListNubCons
-  :: ( TypeEquals (Symbol.SProxy label) (Symbol.SProxy label')
-     , TypeEquals head head'
-     , TypeEquals (RLProxy nubbed) (RLProxy nubbed')
-     , RowListRemove label tail removed
-     , RowListNub removed nubbed )
-  => RowListNub (Cons label head tail) (Cons label' head' nubbed')
-
--- Append two row lists together
-class RowListAppend (lhs :: RowList)
-                    (rhs :: RowList)
-                    (out :: RowList)
-                    | lhs rhs -> out
-
-instance rowListAppendNil
-  :: TypeEquals (RLProxy rhs) (RLProxy out)
-  => RowListAppend Nil rhs out
-
-instance rowListAppendCons
-  :: ( RowListAppend tail rhs out'
-     , TypeEquals (RLProxy (Cons label head out')) (RLProxy out) )
-  => RowListAppend (Cons label head tail) rhs out
 
 -- | Type application for rows.
 type RowApply (f :: # Type -> # Type) (a :: # Type) = f a

--- a/src/Type/Row/Homogeneous.purs
+++ b/src/Type/Row/Homogeneous.purs
@@ -4,7 +4,7 @@ module Type.Row.Homogeneous
   ) where
 
 import Type.Equality (class TypeEquals)
-import Type.Row (class RowToList, Cons, Nil, kind RowList)
+import Type.RowList (class RowToList, Cons, Nil, kind RowList)
 
 -- | Ensure that every field in a row has the same type.
 class Homogeneous (row :: # Type) fieldType | row -> fieldType

--- a/src/Type/RowList.purs
+++ b/src/Type/RowList.purs
@@ -1,0 +1,94 @@
+module Type.RowList
+  ( module Prim.RowList
+  , module RLProxy
+  , class ListToRow
+  , class RowListRemove
+  , class RowListSet
+  , class RowListNub
+  , class RowListAppend
+  ) where
+
+import Prim.Row as Row
+import Prim.RowList (kind RowList, Cons, Nil, class RowToList)
+import Type.Equality (class TypeEquals)
+import Type.Data.Symbol as Symbol
+import Type.Data.Boolean as Boolean
+import Type.Data.RowList (RLProxy)
+import Type.Data.RowList (RLProxy(..)) as RLProxy
+
+-- | Convert a RowList to a row of types.
+-- | The inverse of this operation is `RowToList`.
+class ListToRow (list :: RowList)
+                (row :: # Type) |
+                list -> row
+
+instance listToRowNil
+  :: ListToRow Nil ()
+
+instance listToRowCons
+  :: ( ListToRow tail tailRow
+     , Row.Cons label ty tailRow row )
+  => ListToRow (Cons label ty tail) row
+
+-- | Remove all occurences of a given label from a RowList
+class RowListRemove (label :: Symbol)
+                    (input :: RowList)
+                    (output :: RowList)
+                    | label input -> output
+
+instance rowListRemoveNil
+  :: RowListRemove label Nil Nil
+
+instance rowListRemoveCons
+  :: ( RowListRemove label tail tailOutput
+     , Symbol.Equals label key eq
+     , Boolean.If eq
+         (RLProxy tailOutput)
+         (RLProxy (Cons key head tailOutput))
+         (RLProxy output)
+     )
+  => RowListRemove label (Cons key head tail) output
+
+-- | Add a label to a RowList after removing other occurences.
+class RowListSet (label :: Symbol)
+                 (typ :: Type)
+                 (input :: RowList)
+                 (output :: RowList)
+                 | label typ input -> output
+
+instance rowListSetImpl
+  :: ( TypeEquals (Symbol.SProxy label) (Symbol.SProxy label')
+     , TypeEquals typ typ'
+     , RowListRemove label input lacking )
+  => RowListSet label typ input (Cons label' typ' lacking)
+
+-- | Remove label duplicates, keeps earlier occurrences.
+class RowListNub (input :: RowList)
+                 (output :: RowList)
+                 | input -> output
+
+instance rowListNubNil
+  :: RowListNub Nil Nil
+
+instance rowListNubCons
+  :: ( TypeEquals (Symbol.SProxy label) (Symbol.SProxy label')
+     , TypeEquals head head'
+     , TypeEquals (RLProxy nubbed) (RLProxy nubbed')
+     , RowListRemove label tail removed
+     , RowListNub removed nubbed )
+  => RowListNub (Cons label head tail) (Cons label' head' nubbed')
+
+-- Append two row lists together
+class RowListAppend (lhs :: RowList)
+                    (rhs :: RowList)
+                    (out :: RowList)
+                    | lhs rhs -> out
+
+instance rowListAppendNil
+  :: TypeEquals (RLProxy rhs) (RLProxy out)
+  => RowListAppend Nil rhs out
+
+instance rowListAppendCons
+  :: ( RowListAppend tail rhs out'
+     , TypeEquals (RLProxy (Cons label head out')) (RLProxy out) )
+  => RowListAppend (Cons label head tail) rhs out


### PR DESCRIPTION
Refs #43, fixes #46.

RowList-related types and classes have been removed from Type.Row and
moved into Type.RowList, in order to prepare for an upcoming compiler
change whereby a module will no longer be allowed to re-export both a
type and a class of the same name; see purescript/purescript#3502