### PR TITLE
added Compare classes to Ordering

### DIFF
--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -9,12 +9,26 @@ module Type.Data.Ordering
   , class Invert
   , invert
   , class Equals
+  , class Compare
+  , compare
+  , class IsLt
+  , isLt
+  , class IsEq
+  , isEq
+  , class IsGt
+  , isGt
+  , class IsLte
+  , isLte
+  , class IsGte
+  , isGte
   , equals
   ) where
 
-import Prim.Ordering (kind Ordering, LT, EQ, GT)
 import Data.Ordering (Ordering(..))
-import Type.Data.Boolean (kind Boolean, True, False, BProxy(..))
+import Data.Symbol (SProxy)
+import Prim.Ordering (kind Ordering, LT, EQ, GT)
+import Prim.Symbol (class Compare) as Symbol
+import Type.Data.Boolean (class Or, BProxy(..), False, True, kind Boolean)
 
 -- | Value proxy for `Ordering` types
 data OProxy (ordering :: Ordering) = OProxy
@@ -75,3 +89,40 @@ instance equalsGTEQ :: Equals GT EQ False
 equals :: forall l r o. Equals l r o => OProxy l -> OProxy r -> BProxy o
 equals _ _ = BProxy
 
+-- | Compares type a b
+class Compare a b (o :: Ordering) | a b -> o
+
+compare :: forall a b o. Compare a b o => a -> b -> OProxy o
+compare _ _ = OProxy
+
+class IsLt a b (isLt :: Boolean) | a b -> isLt
+instance isLtTrue ∷ (Compare a b o, Equals o LT isLt) => IsLt a b isLt
+
+isLt :: forall a b isLt. IsLt a b isLt => a -> b -> BProxy isLt
+isLt _ _ = BProxy
+
+class IsGt a b (isGt :: Boolean) | a b -> isGt
+instance isGtCompare :: (Compare a b o, Equals o GT isGt) => IsGt a b isGt
+
+isGt :: forall a b isGt. IsGt a b isGt => a -> b -> BProxy isGt
+isGt _ _ = BProxy
+
+class IsEq a b (isEq :: Boolean) | a b -> isEq
+instance isEqCompare :: (Compare a b o, Equals o EQ isEq) => IsEq a b isEq
+
+isEq :: forall a b isEq. IsEq a b isEq => a -> b -> BProxy isEq
+isEq _ _ = BProxy
+
+class IsLte a b (isLte :: Boolean) | a b -> isLte
+instance isLteFromIs ∷ (IsEq a b isEq, IsLt a b isLt, Or isEq isLt isLte) => IsLte a b isLte
+
+isLte :: forall a b isLte. IsLte a b isLte => a -> b -> BProxy isLte
+isLte _ _ = BProxy
+
+class IsGte a b (isGte :: Boolean) | a b -> isGte
+instance isGteFromIs :: (IsEq a b isEq, IsGt a b isGt, Or isEq isGt isGte) => IsGte a b isGte
+
+isGte :: forall a b isGte. IsGte a b isGte => a -> b -> BProxy isGte
+isGte _ _ = BProxy
+
+instance compareOrd :: Symbol.Compare lhs rhs ord => Compare (SProxy lhs) (SProxy rhs) ord


### PR DESCRIPTION
This PR adds a Typelevel Compare Type-Class, which can be used for comparing custom types (like Typelevel Numbers). 

The PR also adds helper classes like `Lte a b isLte`