### PR TITLE
Add Mirror and Snoc type classes to Symbol

### DIFF
--- a/src/Type/Data/Symbol.purs
+++ b/src/Type/Data/Symbol.purs
@@ -5,6 +5,11 @@ module Type.Data.Symbol
   , compare
   , uncons
   , class Equals
+  , class Mirror
+  , class MirrorP
+  , mirror
+  , class Snoc
+  , snoc
   , equals
   ) where
 
@@ -36,3 +41,35 @@ instance equalsSymbol
 equals :: forall l r o. Equals l r o => SProxy l -> SProxy r -> BProxy o
 equals _ _ = BProxy
 
+
+-- Mirror
+
+class MirrorP (a :: Symbol) (mirror :: Symbol) | a -> mirror, mirror -> a
+
+instance mirrorEmpty :: MirrorP "" ""
+else
+instance mirrorCons :: (Cons head tail sym, MirrorP tailMirror tail, MirrorP tail tailMirror, Append tailMirror head mirror) => MirrorP sym mirror
+
+class Mirror (a :: Symbol) (mirror :: Symbol) | a -> mirror, mirror -> a
+
+instance mirrorMirrorP :: (MirrorP a b, MirrorP b a) => Mirror a b
+
+mirror :: ∀a b. Mirror a b => SProxy a -> SProxy b
+mirror _ = SProxy
+
+-- Snoc
+
+--| ```purescript
+--| Snoc "symbo" "l" ?x ~~> ?x = "symbol"
+--| Snoc ?a ?b "symbol" ~~> ?a = "symbo", ?b = "l"
+--| ```
+-- | `end` must be a single character
+class Snoc (list :: Symbol) (end :: Symbol) (symbol :: Symbol) | end list -> symbol, symbol -> end list
+
+instance snocMirror :: (Mirror sym mirror, Cons end listMirror mirror, Mirror listMirror list) => Snoc list end sym
+
+--| ```purescript
+--| snoc (SProxy :: SProxy "symbo") (SProxy :: SProxy "l") = SProxy :: SProxy "symbol"
+--| ```
+snoc :: ∀a b c. Snoc a b c => SProxy a -> SProxy b -> SProxy c
+snoc _ _ = SProxy


### PR DESCRIPTION
This PR adds Type-Classes for Mirroring Symbols ("Test" ~> "tseT") and Snoc ("Tes" "t" ~> "Test").

These Type-Classes can be useful when parsing Symbols to Numbers. 

If this is to esoteric for the typelevel-prelude, feel free to reject the PR.