### PR TITLE
Make the instance rowListAppendNil simple (remove type constraint)

### DIFF
--- a/src/Type/RowList.purs
+++ b/src/Type/RowList.purs
@@ -84,9 +84,7 @@ class RowListAppend (lhs :: RowList)
                     (out :: RowList)
                     | lhs rhs -> out
 
-instance rowListAppendNil
-  :: TypeEquals (RLProxy rhs) (RLProxy out)
-  => RowListAppend Nil rhs out
+instance rowListAppendNil :: RowListAppend Nil rhs rhs
 
 instance rowListAppendCons
   :: ( RowListAppend tail rhs out'


### PR DESCRIPTION
Hi maintainers,

I think it is more simple.
(All I am worrying is if this is coding rule)