### PR TITLE
Re-add re-exports of Ordering and Boolean

### DIFF
--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -8,8 +8,8 @@ module Type.Prelude
   , module Type.RowList
   ) where
 
-import Type.Data.Boolean (True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
-import Type.Data.Ordering (LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
+import Type.Data.Boolean (kind Boolean, True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
+import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
 import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class Compare, compare, class Append, append)
 import Type.Equality (class TypeEquals, from, to)


### PR DESCRIPTION
Fixes #55. This re-adds the re-exports of the Ordering and Boolean kinds
to the module `Type.Prelude`, as they were erroneously removed due to
an incorrect compiler warning.