### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -9,7 +9,7 @@ module Type.Prelude
   ) where
 
 import Type.Data.Boolean (True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
-import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
+import Type.Data.Ordering (Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
 import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class Compare, compare, class Append, append)
 import Type.Equality (class TypeEquals, from, to)

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -25,8 +25,13 @@ infixr 0 type APPLY as $
 -- | ```
 -- | FLIP Int Maybe == Maybe Int
 -- | ```
--- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed since
--- | `Row Type` is an alias for `Row Type`
+-- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed.
+-- | Before the `0.14.0` release, we used `# Type` to refer to a row of types.
+-- | In  the `0.14.0` release, the `# Type` syntax was deprecated,
+-- | and `Row Type` is the correct way to do this now. To help mitigate
+-- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
+-- | syntax is fully dropped in a later language release, we can then
+-- | support the infix version: `Int # Maybe`.
 type FLIP ∷ ∀ d c . d → (d → c) → c
 type FLIP a f = f a
 

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -26,7 +26,7 @@ infixr 0 type APPLY as $
 -- | FLIP Int Maybe == Maybe Int
 -- | ```
 -- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed since
--- | `# Type` is an alias for `Row Type`
+-- | `Row Type` is an alias for `Row Type`
 type FLIP ∷ ∀ d c . d → (d → c) → c
 type FLIP a f = f a
 

--- a/src/Type/Row/Homogeneous.purs
+++ b/src/Type/Row/Homogeneous.purs
@@ -4,7 +4,7 @@ module Type.Row.Homogeneous
   ) where
 
 import Type.Equality (class TypeEquals)
-import Type.RowList (class RowToList, Cons, Nil, kind RowList)
+import Type.RowList (class RowToList, Cons, Nil, RowList)
 
 -- | Ensure that every field in a row has the same type.
 class Homogeneous :: forall k. Row k -> k -> Constraint

--- a/src/Type/RowList.purs
+++ b/src/Type/RowList.purs
@@ -9,7 +9,7 @@ module Type.RowList
   ) where
 
 import Prim.Row as Row
-import Prim.RowList (kind RowList, Cons, Nil, class RowToList)
+import Prim.RowList (RowList, Cons, Nil, class RowToList)
 import Type.Equality (class TypeEquals)
 import Type.Data.Symbol as Symbol
 import Type.Data.Boolean as Boolean


### PR DESCRIPTION
Fixes the compiler warnings I missed in #57 

However, I'm not sure what to do about this compiler warning:
```
Warning 1 of 71:

  in module Type.Data.Ordering
  at .spago/typelevel-prelude/master/src/Type/Data/Ordering.purs:15:1 - 15:27 (line 15, column 1 - line 15, column 27)

    Module Prim.Ordering was imported as PO with unspecified imports.
    As this module is being re-exported, consider using the explicit form:

      import Prim.Ordering (EQ, GT, LT, Ordering) as PO

  See https://github.com/purescript/documentation/blob/master/errors/ImplicitQualifiedImportReExport.md for more information,
  or to contribute content related to this warning.
```