### PR TITLE
Update to v0.14.0-rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js: stable
 env:
   - PATH=$HOME/purescript:$PATH
 install:
-  - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
+  # - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
+  - TAG=v0.14.0-rc2
   - curl --location --output $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/
   - chmod a+x $HOME/purescript

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-proxy": "^3.0.0",
     "purescript-prelude": "^4.1.0",
     "purescript-type-equality": "^3.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.1.0",
-    "purescript-type-equality": "^3.0.0"
+    "purescript-prelude": "master",
+    "purescript-type-equality": "master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "pulp": "^15.0.0",
-    "purescript-psa": "^0.6.0",
+    "purescript-psa": "^0.8.0",
     "rimraf": "^2.6.2"
   }
 }

--- a/src/Type/Data/Boolean.purs
+++ b/src/Type/Data/Boolean.purs
@@ -18,6 +18,7 @@ import Prim.Boolean (True, False)
 import Type.Proxy (Proxy(..))
 
 -- | Value proxy for `Boolean` types
+-- | **Deprecated:** Use `Type.Proxy` instead
 data BProxy :: Boolean -> Type
 data BProxy bool = BProxy
 

--- a/src/Type/Data/Boolean.purs
+++ b/src/Type/Data/Boolean.purs
@@ -22,7 +22,7 @@ data BProxy :: Boolean -> Type
 data BProxy bool = BProxy
 
 -- | Class for reflecting a type level `Boolean` at the value level
-class IsBoolean :: Boolean -> Type
+class IsBoolean :: Boolean -> Constraint
 class IsBoolean bool where
   reflectBoolean :: forall proxy. proxy bool -> Boolean
 

--- a/src/Type/Data/Boolean.purs
+++ b/src/Type/Data/Boolean.purs
@@ -18,19 +18,21 @@ import Prim.Boolean (True, False)
 import Type.Proxy (Proxy(..))
 
 -- | Value proxy for `Boolean` types
-data BProxy (bool :: Boolean) = BProxy
+data BProxy :: Boolean -> Type
+data BProxy bool = BProxy
 
 -- | Class for reflecting a type level `Boolean` at the value level
-class IsBoolean (bool :: Boolean) where
+class IsBoolean :: Boolean -> Type
+class IsBoolean bool where
   reflectBoolean :: forall proxy. proxy bool -> Boolean
 
 instance isBooleanTrue :: IsBoolean True where reflectBoolean _ = true
 instance isBooleanFalse :: IsBoolean False where reflectBoolean _ = false
 
 -- | Use a value level `Boolean` as a type-level `Boolean`
-reifyBoolean :: forall r. Boolean -> (forall o. IsBoolean o => BProxy o -> r) -> r
-reifyBoolean true f = f (BProxy :: BProxy True)
-reifyBoolean false f = f (BProxy :: BProxy False)
+reifyBoolean :: forall r. Boolean -> (forall proxy o. IsBoolean o => proxy o -> r) -> r
+reifyBoolean true f = f (Proxy :: Proxy True)
+reifyBoolean false f = f (Proxy :: Proxy False)
 
 -- | And two `Boolean` types together
 class And :: Boolean -> Boolean -> Boolean -> Constraint

--- a/src/Type/Data/Boolean.purs
+++ b/src/Type/Data/Boolean.purs
@@ -14,7 +14,7 @@ module Type.Data.Boolean
   , if_
   ) where
 
-import Prim.Boolean (kind Boolean, True, False)
+import Prim.Boolean (True, False)
 import Type.Proxy (Proxy(..))
 
 -- | Value proxy for `Boolean` types
@@ -22,7 +22,7 @@ data BProxy (bool :: Boolean) = BProxy
 
 -- | Class for reflecting a type level `Boolean` at the value level
 class IsBoolean (bool :: Boolean) where
-  reflectBoolean :: BProxy bool -> Boolean
+  reflectBoolean :: forall proxy. proxy bool -> Boolean
 
 instance isBooleanTrue :: IsBoolean True where reflectBoolean _ = true
 instance isBooleanFalse :: IsBoolean False where reflectBoolean _ = false
@@ -33,10 +33,8 @@ reifyBoolean true f = f (BProxy :: BProxy True)
 reifyBoolean false f = f (BProxy :: BProxy False)
 
 -- | And two `Boolean` types together
-class And (lhs :: Boolean)
-          (rhs :: Boolean)
-          (output :: Boolean) |
-          lhs rhs -> output
+class And :: Boolean -> Boolean -> Boolean -> Constraint
+class And lhs rhs out | lhs rhs -> out
 instance andTrue :: And True rhs rhs
 instance andFalse :: And False rhs False
 
@@ -44,10 +42,8 @@ and :: forall l r o. And l r o => BProxy l -> BProxy r -> BProxy o
 and _ _ = BProxy
 
 -- | Or two `Boolean` types together
-class Or (lhs :: Boolean)
-         (rhs :: Boolean)
-         (output :: Boolean) |
-         lhs rhs -> output
+class Or :: Boolean -> Boolean -> Boolean -> Constraint
+class Or lhs rhs output | lhs rhs -> output
 instance orTrue :: Or True rhs True
 instance orFalse :: Or False rhs rhs
 
@@ -55,9 +51,8 @@ or :: forall l r o. Or l r o => BProxy l -> BProxy r -> BProxy o
 or _ _ = BProxy
 
 -- | Not a `Boolean`
-class Not (bool :: Boolean)
-          (output :: Boolean) |
-          bool -> output
+class Not :: Boolean -> Boolean -> Constraint
+class Not bool output | bool -> output
 instance notTrue :: Not True False
 instance notFalse :: Not False True
 
@@ -65,11 +60,8 @@ not :: forall i o. Not i o => BProxy i -> BProxy o
 not _ = BProxy
 
 -- | If - dispatch based on a boolean
-class If (bool :: Boolean)
-         (onTrue :: Type)
-         (onFalse :: Type)
-         (output :: Type) |
-         bool onTrue onFalse -> output
+class If :: forall k. Boolean -> k -> k -> k -> Constraint
+class If bool onTrue onFalse output | bool onTrue onFalse -> output
 instance ifTrue :: If True onTrue onFalse onTrue
 instance ifFalse :: If False onTrue onFalse onFalse
 

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -12,8 +12,7 @@ module Type.Data.Ordering
   , equals
   ) where
 
-import Prim.Ordering as PO -- refer to kind Ordering via `PO.Ordering`
-import Prim.Ordering (LT, EQ, GT)
+import Prim.Ordering (LT, EQ, GT, Ordering) as PO
 import Data.Ordering (Ordering(..))
 import Type.Data.Boolean (True, False, BProxy(..))
 import Type.Proxy (Proxy(..))
@@ -27,23 +26,23 @@ class IsOrdering :: PO.Ordering -> Constraint
 class IsOrdering ordering where
   reflectOrdering :: forall proxy. proxy ordering -> Ordering
 
-instance isOrderingLT :: IsOrdering LT where reflectOrdering _ = LT
-instance isOrderingEQ :: IsOrdering EQ where reflectOrdering _ = EQ
-instance isOrderingGT :: IsOrdering GT where reflectOrdering _ = GT
+instance isOrderingLT :: IsOrdering PO.LT where reflectOrdering _ = LT
+instance isOrderingEQ :: IsOrdering PO.EQ where reflectOrdering _ = EQ
+instance isOrderingGT :: IsOrdering PO.GT where reflectOrdering _ = GT
 
 -- | Use a value level `Ordering` as a type-level `Ordering`
 reifyOrdering :: forall r. Ordering -> (forall proxy o. IsOrdering o => proxy o -> r) -> r
-reifyOrdering LT f = f (Proxy :: Proxy LT)
-reifyOrdering EQ f = f (Proxy :: Proxy EQ)
-reifyOrdering GT f = f (Proxy :: Proxy GT)
+reifyOrdering LT f = f (Proxy :: Proxy PO.LT)
+reifyOrdering EQ f = f (Proxy :: Proxy PO.EQ)
+reifyOrdering GT f = f (Proxy :: Proxy PO.GT)
 
 -- | Append two `Ordering` types together
 -- | Reflective of the semigroup for value level `Ordering`
 class Append :: PO.Ordering -> PO.Ordering -> PO.Ordering -> Constraint
 class Append lhs rhs output | lhs -> rhs output
-instance appendOrderingLT :: Append LT rhs LT
-instance appendOrderingEQ :: Append EQ rhs rhs
-instance appendOrderingGT :: Append GT rhs GT
+instance appendOrderingLT :: Append PO.LT rhs PO.LT
+instance appendOrderingEQ :: Append PO.EQ rhs rhs
+instance appendOrderingGT :: Append PO.GT rhs PO.GT
 
 append :: forall l r o. Append l r o => OProxy l -> OProxy r -> OProxy o
 append _ _ = OProxy
@@ -51,9 +50,9 @@ append _ _ = OProxy
 -- | Invert an `Ordering`
 class Invert :: PO.Ordering -> PO.Ordering -> Constraint
 class Invert ordering result | ordering -> result
-instance invertOrderingLT :: Invert LT GT
-instance invertOrderingEQ :: Invert EQ EQ
-instance invertOrderingGT :: Invert GT LT
+instance invertOrderingLT :: Invert PO.LT PO.GT
+instance invertOrderingEQ :: Invert PO.EQ PO.EQ
+instance invertOrderingGT :: Invert PO.GT PO.LT
 
 invert :: forall i o. Invert i o => OProxy i -> OProxy o
 invert _ = OProxy
@@ -61,15 +60,15 @@ invert _ = OProxy
 class Equals :: PO.Ordering -> PO.Ordering -> Boolean -> Constraint
 class Equals lhs rhs out | lhs rhs -> out
 
-instance equalsEQEQ :: Equals EQ EQ True
-instance equalsLTLT :: Equals LT LT True
-instance equalsGTGT :: Equals GT GT True
-instance equalsEQLT :: Equals EQ LT False
-instance equalsEQGT :: Equals EQ GT False
-instance equalsLTEQ :: Equals LT EQ False
-instance equalsLTGT :: Equals LT GT False
-instance equalsGTLT :: Equals GT LT False
-instance equalsGTEQ :: Equals GT EQ False
+instance equalsEQEQ :: Equals PO.EQ PO.EQ True
+instance equalsLTLT :: Equals PO.LT PO.LT True
+instance equalsGTGT :: Equals PO.GT PO.GT True
+instance equalsEQLT :: Equals PO.EQ PO.LT False
+instance equalsEQGT :: Equals PO.EQ PO.GT False
+instance equalsLTEQ :: Equals PO.LT PO.EQ False
+instance equalsLTGT :: Equals PO.LT PO.GT False
+instance equalsGTLT :: Equals PO.GT PO.LT False
+instance equalsGTEQ :: Equals PO.GT PO.EQ False
 
 equals :: forall l r o. Equals l r o => OProxy l -> OProxy r -> BProxy o
 equals _ _ = BProxy

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -16,6 +16,7 @@ import Prim.Ordering as PO -- refer to kind Ordering via `PO.Ordering`
 import Prim.Ordering (LT, EQ, GT)
 import Data.Ordering (Ordering(..))
 import Type.Data.Boolean (True, False, BProxy(..))
+import Type.Proxy (Proxy(..))
 
 -- | Value proxy for `Ordering` types
 data OProxy :: PO.Ordering -> Type
@@ -31,10 +32,10 @@ instance isOrderingEQ :: IsOrdering EQ where reflectOrdering _ = EQ
 instance isOrderingGT :: IsOrdering GT where reflectOrdering _ = GT
 
 -- | Use a value level `Ordering` as a type-level `Ordering`
-reifyOrdering :: forall r. Ordering -> (forall o. IsOrdering o => OProxy o -> r) -> r
-reifyOrdering LT f = f (OProxy :: OProxy LT)
-reifyOrdering EQ f = f (OProxy :: OProxy EQ)
-reifyOrdering GT f = f (OProxy :: OProxy GT)
+reifyOrdering :: forall r. Ordering -> (forall o. IsOrdering o => Proxy o -> r) -> r
+reifyOrdering LT f = f (Proxy :: Proxy LT)
+reifyOrdering EQ f = f (Proxy :: Proxy EQ)
+reifyOrdering GT f = f (Proxy :: Proxy GT)
 
 -- | Append two `Ordering` types together
 -- | Reflective of the semigroup for value level `Ordering`

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -18,10 +18,12 @@ import Data.Ordering (Ordering(..))
 import Type.Data.Boolean (True, False, BProxy(..))
 
 -- | Value proxy for `Ordering` types
-data OProxy (ordering :: PO.Ordering) = OProxy
+data OProxy :: PO.Ordering -> Type
+data OProxy ordering = OProxy
 
 -- | Class for reflecting a type level `Ordering` at the value level
-class IsOrdering (ordering :: PO.Ordering) where
+class IsOrdreing :: PO.Ordering -> Constraint
+class IsOrdering ordering where
   reflectOrdering :: forall proxy. proxy ordering -> Ordering
 
 instance isOrderingLT :: IsOrdering LT where reflectOrdering _ = LT

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -18,6 +18,7 @@ import Type.Data.Boolean (True, False, BProxy(..))
 import Type.Proxy (Proxy(..))
 
 -- | Value proxy for `Ordering` types
+-- | **Deprecated:** Use `Type.Proxy` instead
 data OProxy :: PO.Ordering -> Type
 data OProxy ordering = OProxy
 

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -32,7 +32,7 @@ instance isOrderingEQ :: IsOrdering EQ where reflectOrdering _ = EQ
 instance isOrderingGT :: IsOrdering GT where reflectOrdering _ = GT
 
 -- | Use a value level `Ordering` as a type-level `Ordering`
-reifyOrdering :: forall r. Ordering -> (forall o. IsOrdering o => Proxy o -> r) -> r
+reifyOrdering :: forall r. Ordering -> (forall proxy o. IsOrdering o => proxy o -> r) -> r
 reifyOrdering LT f = f (Proxy :: Proxy LT)
 reifyOrdering EQ f = f (Proxy :: Proxy EQ)
 reifyOrdering GT f = f (Proxy :: Proxy GT)

--- a/src/Type/Data/Ordering.purs
+++ b/src/Type/Data/Ordering.purs
@@ -23,7 +23,7 @@ data OProxy :: PO.Ordering -> Type
 data OProxy ordering = OProxy
 
 -- | Class for reflecting a type level `Ordering` at the value level
-class IsOrdreing :: PO.Ordering -> Constraint
+class IsOrdering :: PO.Ordering -> Constraint
 class IsOrdering ordering where
   reflectOrdering :: forall proxy. proxy ordering -> Ordering
 

--- a/src/Type/Data/Symbol.purs
+++ b/src/Type/Data/Symbol.purs
@@ -12,7 +12,7 @@ import Prim.Symbol (class Append, class Compare, class Cons)
 import Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol)
 import Type.Data.Ordering (OProxy(..), EQ)
 import Type.Data.Ordering (class Equals) as Ordering
-import Type.Data.Boolean (kind Boolean, BProxy(..))
+import Type.Data.Boolean (BProxy(..))
 
 compare :: forall l r o. Compare l r o => SProxy l -> SProxy r -> OProxy o
 compare _ _ = OProxy
@@ -23,10 +23,8 @@ append _ _ = SProxy
 uncons :: forall h t s. Cons h t s => SProxy s -> {head :: SProxy h, tail :: SProxy t}
 uncons _ = {head : SProxy, tail : SProxy}
 
-class Equals (lhs :: Symbol)
-             (rhs :: Symbol)
-             (out :: Boolean) |
-             lhs rhs -> out
+class Equals :: Symbol -> Symbol -> Boolean -> Constraint
+class Equals lhs rhs out | lhs rhs -> out
 
 instance equalsSymbol
   :: (Compare lhs rhs ord,
@@ -35,4 +33,3 @@ instance equalsSymbol
 
 equals :: forall l r o. Equals l r o => SProxy l -> SProxy r -> BProxy o
 equals _ _ = BProxy
-

--- a/src/Type/Function.purs
+++ b/src/Type/Function.purs
@@ -1,0 +1,28 @@
+module Type.Function where
+
+-- | Polymorphic Type application
+-- |
+-- | For example...
+-- | ```
+-- | APPLY Maybe Int == Maybe $ Int == Maybe Int
+-- | ```
+type APPLY :: forall a b. (a -> b) -> a -> b
+type APPLY f a = f a
+
+infixr 0 type APPLY as $
+
+-- | Reversed polymorphic Type application
+-- |
+-- | For example...
+-- | ```
+-- | FLIP Int Maybe == Maybe Int
+-- | ```
+-- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed.
+-- | Before the `0.14.0` release, we used `# Type` to refer to a row of types.
+-- | In  the `0.14.0` release, the `# Type` syntax was deprecated,
+-- | and `Row Type` is the correct way to do this now. To help mitigate
+-- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
+-- | syntax is fully dropped in a later language release, we can then
+-- | support the infix version: `Int # Maybe`.
+type FLIP :: forall a b. a -> (a -> b) -> b
+type FLIP a f = f a

--- a/src/Type/Prelude.purs
+++ b/src/Type/Prelude.purs
@@ -8,8 +8,8 @@ module Type.Prelude
   , module Type.RowList
   ) where
 
-import Type.Data.Boolean (kind Boolean, True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
-import Type.Data.Ordering (kind Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
+import Type.Data.Boolean (True, False, BProxy(..), class IsBoolean, reflectBoolean, reifyBoolean)
+import Type.Data.Ordering (Ordering, LT, EQ, GT, OProxy(..), class IsOrdering, reflectOrdering, reifyOrdering)
 import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol, class Compare, compare, class Append, append)
 import Type.Equality (class TypeEquals, from, to)

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -8,33 +8,6 @@ module Type.Row
 import Prim.Row (class Lacks, class Nub, class Cons, class Union)
 import Type.Data.Row (RProxy(..)) as RProxy
 
--- | Polymorphic Type application
--- |
--- | For example...
--- | ```
--- | APPLY Maybe Int == Maybe $ Int == Maybe Int
--- | ```
-type APPLY :: forall a b. (a -> b) -> a -> b
-type APPLY f a = f a
-
-infixr 0 type APPLY as $
-
--- | Reversed polymorphic Type application
--- |
--- | For example...
--- | ```
--- | FLIP Int Maybe == Maybe Int
--- | ```
--- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed.
--- | Before the `0.14.0` release, we used `# Type` to refer to a row of types.
--- | In  the `0.14.0` release, the `# Type` syntax was deprecated,
--- | and `Row Type` is the correct way to do this now. To help mitigate
--- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
--- | syntax is fully dropped in a later language release, we can then
--- | support the infix version: `Int # Maybe`.
-type FLIP :: forall a b. a -> (a -> b) -> b
-type FLIP a f = f a
-
 -- | Type application for rows.
 type RowApply :: forall k. (Row k -> Row k) -> Row k -> Row k
 type RowApply f a = f a

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -8,8 +8,36 @@ module Type.Row
 import Prim.Row (class Lacks, class Nub, class Cons, class Union)
 import Type.Data.Row (RProxy(..)) as RProxy
 
+-- | Polymorphic Type application
+-- |
+-- | For example...
+-- | ```
+-- | APPLY Maybe Int == Maybe $ Int == Maybe Int
+-- | ```
+type APPLY ∷ ∀ d c . (d → c) → d → c
+type APPLY f a = f a
+
+infixr 0 type APPLY as $
+
+-- | Reversed polymorphic Type application
+-- |
+-- | For example...
+-- | ```
+-- | FLIP Int Maybe == Maybe Int
+-- | ```
+-- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed.
+-- | Before the `0.14.0` release, we used `# Type` to refer to a row of types.
+-- | In  the `0.14.0` release, the `# Type` syntax was deprecated,
+-- | and `Row Type` is the correct way to do this now. To help mitigate
+-- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
+-- | syntax is fully dropped in a later language release, we can then
+-- | support the infix version: `Int # Maybe`.
+type FLIP ∷ ∀ d c . d → (d → c) → c
+type FLIP a f = f a
+
 -- | Type application for rows.
-type RowApply (f :: # Type -> # Type) (a :: # Type) = f a
+type RowApply :: forall k. (Row k -> Row k) -> Row k -> Row k
+type RowApply f a = f a
 
 -- | Applies a type alias of open rows to a set of rows. The primary use case
 -- | this operator is as convenient sugar for combining open rows without

--- a/src/Type/Row.purs
+++ b/src/Type/Row.purs
@@ -14,7 +14,7 @@ import Type.Data.Row (RProxy(..)) as RProxy
 -- | ```
 -- | APPLY Maybe Int == Maybe $ Int == Maybe Int
 -- | ```
-type APPLY ∷ ∀ d c . (d → c) → d → c
+type APPLY :: forall a b. (a -> b) -> a -> b
 type APPLY f a = f a
 
 infixr 0 type APPLY as $
@@ -32,7 +32,7 @@ infixr 0 type APPLY as $
 -- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
 -- | syntax is fully dropped in a later language release, we can then
 -- | support the infix version: `Int # Maybe`.
-type FLIP ∷ ∀ d c . d → (d → c) → c
+type FLIP :: forall a b. a -> (a -> b) -> b
 type FLIP a f = f a
 
 -- | Type application for rows.

--- a/src/Type/Row/Homogeneous.purs
+++ b/src/Type/Row/Homogeneous.purs
@@ -4,16 +4,18 @@ module Type.Row.Homogeneous
   ) where
 
 import Type.Equality (class TypeEquals)
-import Type.RowList (class RowToList, Cons, Nil, kind RowList)
+import Type.RowList (class RowToList, Cons, Nil, RowList)
 
 -- | Ensure that every field in a row has the same type.
-class Homogeneous (row :: # Type) fieldType | row -> fieldType
+class Homogeneous :: forall k. Row k -> k -> Constraint
+class Homogeneous row fieldType | row -> fieldType
 instance homogeneous
   :: ( RowToList row fields
      , HomogeneousRowList fields fieldType )
   => Homogeneous row fieldType
 
-class HomogeneousRowList (rowList :: RowList) fieldType | rowList -> fieldType
+class HomogeneousRowList :: forall k. RowList k -> k -> Constraint
+class HomogeneousRowList rowList fieldType | rowList -> fieldType
 instance homogeneousRowListCons
   :: ( HomogeneousRowList tail fieldType
      , TypeEquals fieldType fieldType2 )

--- a/src/Type/RowList.purs
+++ b/src/Type/RowList.purs
@@ -9,7 +9,7 @@ module Type.RowList
   ) where
 
 import Prim.Row as Row
-import Prim.RowList (kind RowList, Cons, Nil, class RowToList)
+import Prim.RowList (RowList, Cons, Nil, class RowToList)
 import Type.Equality (class TypeEquals)
 import Type.Data.Symbol as Symbol
 import Type.Data.Boolean as Boolean
@@ -18,9 +18,8 @@ import Type.Data.RowList (RLProxy(..)) as RLProxy
 
 -- | Convert a RowList to a row of types.
 -- | The inverse of this operation is `RowToList`.
-class ListToRow (list :: RowList)
-                (row :: # Type) |
-                list -> row
+class ListToRow :: forall k. RowList k -> Row k -> Constraint
+class ListToRow list row | list -> row
 
 instance listToRowNil
   :: ListToRow Nil ()
@@ -31,10 +30,8 @@ instance listToRowCons
   => ListToRow (Cons label ty tail) row
 
 -- | Remove all occurences of a given label from a RowList
-class RowListRemove (label :: Symbol)
-                    (input :: RowList)
-                    (output :: RowList)
-                    | label input -> output
+class RowListRemove :: forall k. Symbol -> RowList k -> RowList k -> Constraint
+class RowListRemove label input output | label input -> output
 
 instance rowListRemoveNil
   :: RowListRemove label Nil Nil
@@ -50,11 +47,8 @@ instance rowListRemoveCons
   => RowListRemove label (Cons key head tail) output
 
 -- | Add a label to a RowList after removing other occurences.
-class RowListSet (label :: Symbol)
-                 (typ :: Type)
-                 (input :: RowList)
-                 (output :: RowList)
-                 | label typ input -> output
+class RowListSet :: forall k. Symbol -> k -> RowList k -> RowList k -> Constraint
+class RowListSet label typ input output | label typ input -> output
 
 instance rowListSetImpl
   :: ( TypeEquals (Symbol.SProxy label) (Symbol.SProxy label')
@@ -63,9 +57,8 @@ instance rowListSetImpl
   => RowListSet label typ input (Cons label' typ' lacking)
 
 -- | Remove label duplicates, keeps earlier occurrences.
-class RowListNub (input :: RowList)
-                 (output :: RowList)
-                 | input -> output
+class RowListNub :: forall k. RowList k -> RowList k -> Constraint
+class RowListNub input output | input -> output
 
 instance rowListNubNil
   :: RowListNub Nil Nil
@@ -79,10 +72,8 @@ instance rowListNubCons
   => RowListNub (Cons label head tail) (Cons label' head' nubbed')
 
 -- Append two row lists together
-class RowListAppend (lhs :: RowList)
-                    (rhs :: RowList)
-                    (out :: RowList)
-                    | lhs rhs -> out
+class RowListAppend :: forall k. RowList k -> RowList k -> RowList k -> Constraint
+class RowListAppend lhs rhs out | lhs rhs -> out
 
 instance rowListAppendNil
   :: TypeEquals (RLProxy rhs) (RLProxy out)


### PR DESCRIPTION
- Builds off of #58
- updates CI to use v0.14.0-rc2
- Updates dependencies to master and drops the `proxy` dependency as this is now (or soon will be) included in `prelude`

Note: this does produce the following compiler warning, which I had forgotten about:
```
[1/1 ImplicitQualifiedImportReExport] .spago/typelevel-prelude/v5.0.2/src/Type/Data/Ordering.purs:15:1

  15  import Prim.Ordering as PO -- refer to kind Ordering via `PO.Ordering`
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  Module Prim.Ordering was imported as PO with unspecified imports.
  As this module is being re-exported, consider using the explicit form:
  
    import Prim.Ordering (EQ, GT, LT, Ordering) as PO
```