### PR TITLE
Add FLIP infix operator: #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` (#72 by @JordanMartinez)
 
 New features:
+- Added `#` infix operator for `FLIP` (e.g. `Int # Maybe` == `Maybe Int`) (#73 by @JordanMartinez)
 
 Bugfixes:
 

--- a/src/Type/Function.purs
+++ b/src/Type/Function.purs
@@ -15,14 +15,9 @@ infixr 0 type APPLY as $
 -- |
 -- | For example...
 -- | ```
--- | FLIP Int Maybe == Maybe Int
+-- | FLIP Int Maybe == Int # Maybe == Maybe Int
 -- | ```
--- | Note: an infix for FLIP (e.g. `Int # Maybe`) is not allowed.
--- | Before the `0.14.0` release, we used `# Type` to refer to a row of types.
--- | In  the `0.14.0` release, the `# Type` syntax was deprecated,
--- | and `Row Type` is the correct way to do this now. To help mitigate
--- | breakage, `# Type` was made an alias to `Row Type`. When the `# Type`
--- | syntax is fully dropped in a later language release, we can then
--- | support the infix version: `Int # Maybe`.
 type FLIP :: forall a b. a -> (a -> b) -> b
 type FLIP a f = f a
+
+infixl 1 type FLIP as #


### PR DESCRIPTION
**Description of the change**

Not sure whether this is actually wanted, but it does follow what we already have for `$` with APPLY. Infix direction and precedence follows value-level `#`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
